### PR TITLE
fix: color iOS system bars and pad bottom safe-area

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <link rel="apple-touch-icon" href="icons/icon-180.png">
 <link rel="manifest" href="manifest.webmanifest">
+<meta name="theme-color" content="#0b0b0d">
 
 <style>
 :root{
@@ -18,7 +19,8 @@
 }
 *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
 html,body{
-  height:100%; margin:0; background:radial-gradient(circle at top left,#1a1a22,var(--bg)); color:var(--text);
+  height:100%; min-height:100vh; margin:0; padding-bottom:env(safe-area-inset-bottom);
+  background:radial-gradient(circle at top left,#1a1a22,var(--bg)); color:var(--text);
   font-family:-apple-system,BlinkMacSystemFont,"SF Pro",Roboto,system-ui,sans-serif;
   overflow:auto; touch-action:manipulation;
 }


### PR DESCRIPTION
## Summary
- set meta theme-color to app background
- pad body for the bottom safe area to avoid white strip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898dbb783e08322ae3eb75a4bd9d0a8